### PR TITLE
chore(ci): Replace deprecated bitnami/kafka

### DIFF
--- a/.github/workflows/test-kafka.yml
+++ b/.github/workflows/test-kafka.yml
@@ -16,27 +16,27 @@ jobs:
     runs-on: ubuntu-latest
     services:
       kafka:
-        image: bitnami/kafka:4.0.0
+        image: apache/kafka:4.0.0
         env:
           # Enable KRaft mode
-          KAFKA_ENABLE_KRAFT: 'yes'
+          KAFKA_ENABLE_KRAFT: "yes"
           KAFKA_CFG_PROCESS_ROLES: broker,controller
           KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
           KAFKA_CFG_NODE_ID: 1
-          KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: '1@127.0.0.1:9093'
+          KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: "1@127.0.0.1:9093"
 
           # Listeners
-          KAFKA_CFG_LISTENERS: 'PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:9094'
-          KAFKA_CFG_ADVERTISED_LISTENERS: 'PLAINTEXT://127.0.0.1:9092,EXTERNAL://kafka:9094'
-          KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: 'CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT'
-          KAFKA_CFG_INTER_BROKER_LISTENER_NAME: 'PLAINTEXT'
+          KAFKA_CFG_LISTENERS: "PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:9094"
+          KAFKA_CFG_ADVERTISED_LISTENERS: "PLAINTEXT://127.0.0.1:9092,EXTERNAL://kafka:9094"
+          KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT"
+          KAFKA_CFG_INTER_BROKER_LISTENER_NAME: "PLAINTEXT"
 
           # Additional settings
-          KAFKA_BROKER_ID: '1'
-          KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
-          KAFKA_CFG_NUM_PARTITIONS: '2'
-          ALLOW_PLAINTEXT_LISTENER: 'yes'
-          BITNAMI_DEBUG: 'yes'
+          KAFKA_BROKER_ID: "1"
+          KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+          KAFKA_CFG_NUM_PARTITIONS: "2"
+          ALLOW_PLAINTEXT_LISTENER: "yes"
+          BITNAMI_DEBUG: "yes"
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Bitnami has deprecated their public catalog:

> ⚠️ Important Notice: Upcoming changes to the Bitnami Catalog
> Beginning August 28th, 2025, Bitnami will evolve its public catalog to offer a curated set of hardened, security-focused images under the new [Bitnami Secure Images initiative⁠](https://news.broadcom.com/app-dev/broadcom-introduces-bitnami-secure-images-for-production-ready-containerized-applications). As part of this transition: