### PR TITLE
fix(ios-simulator): use semantic version sort for runtime selection

### DIFF
--- a/ios-simulator/wait-ios-simulator.sh
+++ b/ios-simulator/wait-ios-simulator.sh
@@ -153,7 +153,7 @@ resolve_runtime() {
             or ($p == "xrOS" and .platform == "visionOS")
           )
         | select(.version == $v or (.version | startswith($v + ".")))
-      ] | sort_by(.version) | last // empty
+      ] | sort_by(.version | split(".") | map(tonumber)) | last // empty
     ')
 
     if [ -z "$runtime" ] || [ "$runtime" = "null" ]; then
@@ -172,7 +172,7 @@ resolve_runtime() {
             or ($p == "visionOS" and .platform == "xrOS")
             or ($p == "xrOS" and .platform == "visionOS")
           )
-      ] | sort_by(.version) | last // empty
+      ] | sort_by(.version | split(".") | map(tonumber)) | last // empty
     ')
 
     if [ -z "$runtime" ] || [ "$runtime" = "null" ]; then


### PR DESCRIPTION
sort_by(.version) is lexicographic so "9.0" > "18.5". Split version strings into numeric arrays for correct ordering.