### PR TITLE
ci: add required check summary jobs to test workflows

### DIFF
--- a/.github/workflows/test-android-emulator.yml
+++ b/.github/workflows/test-android-emulator.yml
@@ -102,3 +102,18 @@ jobs:
       - name: Fail if wait succeeded unexpectedly
         if: steps.wait-for-android-emulator.outcome != 'failure'
         run: exit 1
+
+  required-check:
+    name: Test Android Emulator - Required Check
+    needs:
+      - universal-reachable
+      - universal-timeout
+      - dedicated-reachable
+      - dedicated-timeout
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "One of the dependent jobs has failed or was cancelled." && exit 1

--- a/.github/workflows/test-ios-simulator.yml
+++ b/.github/workflows/test-ios-simulator.yml
@@ -93,3 +93,17 @@ jobs:
       - name: Fail if wait succeeded unexpectedly
         if: steps.wait.outcome != 'failure'
         run: exit 1
+
+  required-check:
+    name: Test iOS Simulator - Required Check
+    needs:
+      - boot
+      - no-boot
+      - invalid-device
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "One of the dependent jobs has failed or was cancelled." && exit 1

--- a/.github/workflows/test-kafka.yml
+++ b/.github/workflows/test-kafka.yml
@@ -123,3 +123,18 @@ jobs:
       - name: Fail if wait succeeded unexpectedly
         if: steps.wait-for-kafka.outcome != 'failure'
         run: exit 1
+
+  required-check:
+    name: Test Kafka - Required Check
+    needs:
+      - universal-reachable
+      - universal-timeout
+      - dedicated-reachable
+      - dedicated-timeout
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "One of the dependent jobs has failed or was cancelled." && exit 1

--- a/.github/workflows/test-mongodb.yml
+++ b/.github/workflows/test-mongodb.yml
@@ -96,3 +96,18 @@ jobs:
       - name: Fail if wait succeeded unexpectedly
         if: steps.wait-for-mongodb.outcome != 'failure'
         run: exit 1
+
+  required-check:
+    name: Test MongoDB - Required Check
+    needs:
+      - universal-reachable
+      - universal-timeout
+      - dedicated-reachable
+      - dedicated-timeout
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "One of the dependent jobs has failed or was cancelled." && exit 1

--- a/.github/workflows/test-nats.yml
+++ b/.github/workflows/test-nats.yml
@@ -96,3 +96,18 @@ jobs:
       - name: Fail if wait succeeded unexpectedly
         if: steps.wait-for-nats.outcome != 'failure'
         run: exit 1
+
+  required-check:
+    name: Test NATS - Required Check
+    needs:
+      - universal-reachable
+      - universal-timeout
+      - dedicated-reachable
+      - dedicated-timeout
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "One of the dependent jobs has failed or was cancelled." && exit 1

--- a/.github/workflows/test-postgres.yml
+++ b/.github/workflows/test-postgres.yml
@@ -118,3 +118,18 @@ jobs:
       - name: Fail if wait succeeded unexpectedly
         if: steps.wait-for-postgres.outcome != 'failure'
         run: exit 1
+
+  required-check:
+    name: Test PostgreSQL - Required Check
+    needs:
+      - universal-reachable
+      - universal-timeout
+      - dedicated-reachable
+      - dedicated-timeout
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "One of the dependent jobs has failed or was cancelled." && exit 1

--- a/.github/workflows/test-redis.yml
+++ b/.github/workflows/test-redis.yml
@@ -96,3 +96,18 @@ jobs:
       - name: Fail if wait succeeded unexpectedly
         if: steps.wait-for-redis.outcome != 'failure'
         run: exit 1
+
+  required-check:
+    name: Test Redis - Required Check
+    needs:
+      - universal-reachable
+      - universal-timeout
+      - dedicated-reachable
+      - dedicated-timeout
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "One of the dependent jobs has failed or was cancelled." && exit 1


### PR DESCRIPTION
Add a `required-check` summary job to each multi-job test workflow. This
makes it easier to manage required status checks in the repo's branch
protection settings — instead of listing every individual job, a single
summary check per workflow can be required.

Each summary job uses `if: always()` and depends on all other jobs in the
workflow, failing if any dependency failed or was cancelled while treating
skipped jobs as acceptable.

Workflows with only a single job (`ci.yml`, `build-and-push.yml`) are left
unchanged since a summary check would be redundant there.

**Required check names:**
- `Test Android Emulator - Required Check`
- `Test iOS Simulator - Required Check`
- `Test Kafka - Required Check`
- `Test MongoDB - Required Check`
- `Test NATS - Required Check`
- `Test PostgreSQL - Required Check`
- `Test Redis - Required Check`